### PR TITLE
Adds installer service

### DIFF
--- a/cmd/commandProcessor/process.go
+++ b/cmd/commandProcessor/process.go
@@ -3,6 +3,7 @@ package commandProcessor
 
 import (
 	"os"
+	"sync"
 
 	"github.com/Linkinlog/gasible/cmd/installer"
 	"github.com/Linkinlog/gasible/cmd/yamlParser"
@@ -18,13 +19,17 @@ func ProcessCommand() error {
 	return initProcess()
 }
 
+// Start the machine, handle which services to set up.
 func initProcess() error {
-	// Create a config struct and fill it from the config file
+	// Create a config struct and fill it from the config file.
 	conf := models.Config{}.FillFromFile("")
+	// Create a waitgroup so we can run all services at once.
+	var wg sync.WaitGroup
 
 	if conf.ServicesConfig.Installer {
 		// TODO Make go routine maybe
-		installer.Installer(conf)
+		wg.Add(1)
+		go installer.Installer(conf, &wg)
 	}
 	if conf.ServicesConfig.Ssh {
 		// TODO
@@ -32,5 +37,6 @@ func initProcess() error {
 	if conf.ServicesConfig.Teamviewer {
 		// TODO
 	}
+	wg.Wait()
 	return nil
 }

--- a/cmd/commandProcessor/process.go
+++ b/cmd/commandProcessor/process.go
@@ -3,10 +3,8 @@ package commandProcessor
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/Linkinlog/gasible/cmd/installer"
-	"github.com/Linkinlog/gasible/cmd/osHandler"
 	"github.com/Linkinlog/gasible/cmd/yamlParser"
 	"github.com/Linkinlog/gasible/internal/models"
 )
@@ -21,19 +19,12 @@ func ProcessCommand() error {
 }
 
 func initProcess() error {
-	// Grab system running this software
-	system, err := osHandler.StringToSystem(runtime.GOOS)
-	if err != nil {
-		return err
-	}
-	// Create a config struct for us to fill
-	conf := models.Config{}
-	// Fill the config using the default filepath
-	conf.Fill("")
+	// Create a config struct and fill it from the config file
+	conf := models.Config{}.FillFromFile("")
 
 	if conf.ServicesConfig.Installer {
 		// TODO Make go routine maybe
-		installer.Installer(system, conf.PackageInstallerConfig)
+		installer.Installer(conf)
 	}
 	if conf.ServicesConfig.Ssh {
 		// TODO
@@ -41,5 +32,5 @@ func initProcess() error {
 	if conf.ServicesConfig.Teamviewer {
 		// TODO
 	}
-	return err
+	return nil
 }

--- a/cmd/installer/installPkgs.go
+++ b/cmd/installer/installPkgs.go
@@ -2,11 +2,32 @@ package installer
 
 import (
 	"errors"
+	"os/exec"
+	"strings"
 
 	"github.com/Linkinlog/gasible/cmd/osHandler"
 	"github.com/Linkinlog/gasible/internal/models"
 )
 
-func Installer(s osHandler.System, pkgManagerConf models.PackageInstallerConfig) error {
-    return errors.New("WIP")
+// Install the packages listed in the
+// packages section of the YAML file.
+func Installer(c *models.Config) error {
+	// Verify the OS is supported
+	system := osHandler.GetCurrentSystem()
+    // Validate the package manager
+    pm := c.PackageInstallerConfig.CheckPMAndReturnPath()
+	config := c.PackageInstallerConfig
+	packages := strings.Join(config.Packages, " ")
+    command := strings.Join([]string{pm, config.Args, packages}, " ")
+
+	if system.Name == "linux" || system.Name == "mac" {
+        out, err := exec.Command("/usr/bin/env", "sh", "-c", command).Output()
+        if err != nil {
+            panic(err)
+        }
+        
+	} else if system.Name == "windows" {
+		exec.Command("/usr/bin/env sh", "-c", pm, config.Args, packages)
+	}
+	return errors.New("WIP")
 }

--- a/cmd/osHandler/supportedSystems.go
+++ b/cmd/osHandler/supportedSystems.go
@@ -7,32 +7,41 @@ package osHandler
 
 import (
 	"errors"
-
+	"runtime"
 )
 
 // config contains the name of the configuration and
 // the path we should put the config files / clone the repo to.
 type config struct {
-	name string
-	path string
+	Name string
+	Path string
 }
 
 // os contains the name of the operating system and
 // the configs we want to configure for said OS.
 type System struct {
-	name       string
-	pkgManager string
-	configs    []config
+	Name    string
+	Configs []config
+}
+
+// GetCurrentSystem returns the system struct
+// relative to the current system at runtime.
+func GetCurrentSystem() *System {
+	// Grab system running this software
+	system, err := StringToSystem(runtime.GOOS)
+	if err != nil {
+		panic(err)
+	}
+	return &system
 }
 
 // stringToSystem will take a system as a string value
 // and return it in a struct format as long as it is supported.
 // It will return an error if it is not supported.
 func StringToSystem(s string) (System, error) {
-	switch s {
-	case "win", "linux", "mac":
-		return supportedSystemsMap[s], nil
-	default:
+	if system, exists := supportedSystemsMap[s]; exists {
+		return system, nil
+	} else {
 		return System{}, errors.New("Unsupported system")
 	}
 }
@@ -40,15 +49,14 @@ func StringToSystem(s string) (System, error) {
 // supportedSystemsMap is a map so we can access
 // a System struct by its string value.
 var supportedSystemsMap = map[string]System{
-	"win":   windowsSystem,
-	"linux": linuxSystem,
-	"mac":   macSystem,
+	"windows": windowsSystem,
+	"linux":   linuxSystem,
+	"darwin":  macSystem,
 }
 
 // Default values for a windows OS.
 var windowsSystem = System{
-	"win",
-	"winget",
+	"windows",
 	[]config{
 		{
 			"neovim",
@@ -68,7 +76,6 @@ var windowsSystem = System{
 // Default values for a linux OS.
 var linuxSystem = System{
 	"linux",
-	"dnf",
 	[]config{
 		{
 			"neovim",
@@ -88,7 +95,6 @@ var linuxSystem = System{
 // Default values for a mac OS.
 var macSystem = System{
 	"mac",
-	"brew",
 	[]config{
 		{
 			"neovim",

--- a/cmd/yamlParser/handler_test.go
+++ b/cmd/yamlParser/handler_test.go
@@ -1,38 +1,38 @@
 package yamlParser
 
 import (
+	"os"
 	"testing"
-    "os"
 )
 
 func TestParseGas(t *testing.T) {
 	// We need to make a YAML file but just make it
-    err, file := makeDefaultYAML()
-    if err != nil {
-        panic(err)
-    }
+	err, file := makeDefaultYAML()
+	if err != nil {
+		panic(err)
+	}
 	// Then we need to parse it and make sure we get what we expect
-    gas, err := ParseGas(file)
-    if err != nil {
-        panic(err)
-    }
-    // What do we expect?
-    // TODO: Make test cases so we can go over everything in
-    // * CreateDefaults() and confirm it equals what we expected
+	gas, err := ParseGas(file)
+	if err != nil {
+		panic(err)
+	}
+	// What do we expect?
+	// TODO: Make test cases so we can go over everything in
+	// * CreateDefaults() and confirm it equals what we expected
 }
 
 func makeDefaultYAML() (error, string) {
-    file, err := os.CreateTemp("", "temp")
+	file, err := os.CreateTemp("", "temp")
 	if err != nil {
-        return err, ""
+		return err, ""
 	}
 	defer os.Remove(file.Name())
 
-    _,err = file.WriteString(defaultYAML)
+	_, err = file.WriteString(defaultYAML)
 	if err != nil {
-        return err, ""
+		return err, ""
 	}
-    return nil, file.Name()
+	return nil, file.Name()
 }
 
 const defaultYAML = `

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -24,17 +24,18 @@ func (Conf Config) Default() *Config {
 	}
 }
 
-func (conf *Config) Fill(filePath string) {
+func (conf Config) FillFromFile(filePath string) *Config {
 	if filePath == "" {
 		filePath = "gas.yml"
 	}
 	file, err := os.ReadFile(filePath)
 	if err != nil {
-        panic(err)
+		panic(err)
 	}
 
 	err = yaml.Unmarshal(file, &conf)
 	if err != nil {
-        panic(err)
+		panic(err)
 	}
+	return &conf
 }

--- a/internal/models/Config.go
+++ b/internal/models/Config.go
@@ -6,12 +6,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// The entire config YAML.
 type Config struct {
 	PackageInstallerConfig `yaml:",inline,omitempty"`
 	ServicesConfig         `yaml:",inline,omitempty"`
 	GeneralConfig          `yaml:",inline,omitempty"`
 }
 
+// Create the defaults and write them to *Config.
 func (Conf Config) Default() *Config {
 	pkgInstallConf := PackageInstallerConfig{}.Default()
 	servicesConf := ServicesConfig{}.Default()
@@ -24,6 +26,7 @@ func (Conf Config) Default() *Config {
 	}
 }
 
+// Grab the config from the YAML and write it to *Config.
 func (conf Config) FillFromFile(filePath string) *Config {
 	if filePath == "" {
 		filePath = "gas.yml"

--- a/internal/models/General.go
+++ b/internal/models/General.go
@@ -13,6 +13,7 @@ type TVCreds struct {
 	Pass string `yaml:"pass,omitempty"`
 }
 
+// General configs relating to system setup.
 type GeneralConfig struct {
 	Hostname        string  `yaml:"hostname,omitempty"`
 	IP              string  `yaml:"staticIP,omitempty"`
@@ -20,6 +21,7 @@ type GeneralConfig struct {
 	TeamViewerCreds TVCreds `yaml:"TeamViewerCreds,omitempty"`
 }
 
+// Create the defaults and write them to *GeneralConfig.
 func (GeneralConfig) Default() *GeneralConfig {
 	return &GeneralConfig{
 		Hostname: "development-station",
@@ -32,6 +34,7 @@ func (GeneralConfig) Default() *GeneralConfig {
 	}
 }
 
+// Grab the config from the YAML and write them to *GeneralConfig.
 func (conf GeneralConfig) FillFromFile(filePath string) *GeneralConfig {
 	if filePath == "" {
 		filePath = "gas.yml"
@@ -45,5 +48,5 @@ func (conf GeneralConfig) FillFromFile(filePath string) *GeneralConfig {
 	if err != nil {
 		panic(err)
 	}
-    return &conf
+	return &conf
 }

--- a/internal/models/General.go
+++ b/internal/models/General.go
@@ -6,6 +6,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// The credentials to the teamviewer account.
+// TODO Find a better way to handle this
 type TVCreds struct {
 	User string `yaml:"user,omitempty"`
 	Pass string `yaml:"pass,omitempty"`
@@ -18,7 +20,7 @@ type GeneralConfig struct {
 	TeamViewerCreds TVCreds `yaml:"TeamViewerCreds,omitempty"`
 }
 
-func (General GeneralConfig) Default() *GeneralConfig {
+func (GeneralConfig) Default() *GeneralConfig {
 	return &GeneralConfig{
 		Hostname: "development-station",
 		IP:       "192.168.4.20",
@@ -30,7 +32,7 @@ func (General GeneralConfig) Default() *GeneralConfig {
 	}
 }
 
-func (conf *GeneralConfig) Fill(filePath string) {
+func (conf GeneralConfig) FillFromFile(filePath string) *GeneralConfig {
 	if filePath == "" {
 		filePath = "gas.yml"
 	}
@@ -43,4 +45,5 @@ func (conf *GeneralConfig) Fill(filePath string) {
 	if err != nil {
 		panic(err)
 	}
+    return &conf
 }

--- a/internal/models/Installer.go
+++ b/internal/models/Installer.go
@@ -16,6 +16,7 @@ type PackageInstallerConfig struct {
 	Packages []string `yaml:"packages"`
 }
 
+// Map to validate if a package manager is supported.
 var supportedPM = map[string]bool{
 	"apt-get": true,
 	"yum":     true,
@@ -25,19 +26,21 @@ var supportedPM = map[string]bool{
 	"winget":  true,
 }
 
+// Check if the package manager is supported,
+// and if so, return the full path to it.
 func (p PackageInstallerConfig) CheckPMAndReturnPath() string {
-    fmt.Printf("Package manager: %s \n", p.Manager)
-    pm := p.Manager
+	pm := p.Manager
 	if _, ok := supportedPM[pm]; !ok {
-        err := fmt.Sprintf("Error: Package manager %s not found." , pm)
-        panic(err)
+		err := fmt.Sprintf("Error: Package manager %s not found.", pm)
+		panic(err)
 	}
 	path, err := exec.LookPath(pm)
 	if err != nil {
-        err := fmt.Sprintf("Error: Package manager %s not found." , pm)
-        panic(err)
+		err := fmt.Sprintf("Error: Package manager %s not found.", pm)
+		panic(err)
 	}
 	if os.Geteuid() != 0 {
+		// TODO handle this better
 		//panic("Error: Permission denied.")
 	}
 	return path
@@ -47,7 +50,7 @@ func (p PackageInstallerConfig) CheckPMAndReturnPath() string {
 func (PackageInstallerConfig) Default() *PackageInstallerConfig {
 	return &PackageInstallerConfig{
 		Manager: "dnf",
-		Args:    "install",
+		Args:    "install -y",
 		Packages: []string{
 			"python3-pip",
 			"util-linux-user",

--- a/internal/models/Installer.go
+++ b/internal/models/Installer.go
@@ -1,19 +1,53 @@
 package models
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 
 	"gopkg.in/yaml.v3"
 )
 
+// PackageInstallerConfig holds all fields fields
+// relative to the package installer service.
 type PackageInstallerConfig struct {
-	Manager  string   `yaml:"pkg-manager,omitempty"`
-	Packages []string `yaml:"packages,omitempty"`
+	Manager  string   `yaml:"pkg-manager-command,omitempty"`
+	Args     string   `yaml:"command-args,omitempty"`
+	Packages []string `yaml:"packages"`
 }
 
-func (pkgInstallConf PackageInstallerConfig) Default() *PackageInstallerConfig{
+var supportedPM = map[string]bool{
+	"apt-get": true,
+	"yum":     true,
+	"dnf":     true,
+	"zypper":  true,
+	"pacman":  true,
+	"winget":  true,
+}
+
+func (p PackageInstallerConfig) CheckPMAndReturnPath() string {
+    fmt.Printf("Package manager: %s \n", p.Manager)
+    pm := p.Manager
+	if _, ok := supportedPM[pm]; !ok {
+        err := fmt.Sprintf("Error: Package manager %s not found." , pm)
+        panic(err)
+	}
+	path, err := exec.LookPath(pm)
+	if err != nil {
+        err := fmt.Sprintf("Error: Package manager %s not found." , pm)
+        panic(err)
+	}
+	if os.Geteuid() != 0 {
+		//panic("Error: Permission denied.")
+	}
+	return path
+}
+
+// Populate the struct with the default config for the package installer.
+func (PackageInstallerConfig) Default() *PackageInstallerConfig {
 	return &PackageInstallerConfig{
 		Manager: "dnf",
+		Args:    "install",
 		Packages: []string{
 			"python3-pip",
 			"util-linux-user",
@@ -26,7 +60,8 @@ func (pkgInstallConf PackageInstallerConfig) Default() *PackageInstallerConfig{
 	}
 }
 
-func (conf *PackageInstallerConfig) Fill(filePath string) {
+// Populate the struct with the config file section of the package installer.
+func (conf PackageInstallerConfig) FillFromFile(filePath string) *PackageInstallerConfig {
 	if filePath == "" {
 		filePath = "gas.yml"
 	}
@@ -39,4 +74,5 @@ func (conf *PackageInstallerConfig) Fill(filePath string) {
 	if err != nil {
 		panic(err)
 	}
+	return &conf
 }

--- a/internal/models/Services.go
+++ b/internal/models/Services.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Information relatie to the services we will configure.
 type ServicesConfig struct {
 	Installer  bool `yaml:"installer,omitempty"`
 	Teamviewer bool `yaml:"teamviewer,omitempty"`
@@ -13,6 +14,7 @@ type ServicesConfig struct {
 	Git        bool `yaml:"git,omitempty"`
 }
 
+// Sets the defaults.
 func (ServicesConfig) Default() *ServicesConfig {
 	return &ServicesConfig{
 		Installer:  true,
@@ -22,18 +24,19 @@ func (ServicesConfig) Default() *ServicesConfig {
 	}
 }
 
+// Grabs config from YAML and fills the struct with it.
 func (conf ServicesConfig) FillFromFile(filePath string) *ServicesConfig {
 	if filePath == "" {
 		filePath = "gas.yml"
 	}
 	file, err := os.ReadFile(filePath)
 	if err != nil {
-        panic(err)
+		panic(err)
 	}
 
 	err = yaml.Unmarshal(file, &conf)
 	if err != nil {
-        panic(err)
+		panic(err)
 	}
-    return &conf
+	return &conf
 }

--- a/internal/models/Services.go
+++ b/internal/models/Services.go
@@ -13,7 +13,7 @@ type ServicesConfig struct {
 	Git        bool `yaml:"git,omitempty"`
 }
 
-func (Services ServicesConfig) Default() *ServicesConfig {
+func (ServicesConfig) Default() *ServicesConfig {
 	return &ServicesConfig{
 		Installer:  true,
 		Teamviewer: true,
@@ -22,7 +22,7 @@ func (Services ServicesConfig) Default() *ServicesConfig {
 	}
 }
 
-func (conf *ServicesConfig) Fill(filePath string) {
+func (conf ServicesConfig) FillFromFile(filePath string) *ServicesConfig {
 	if filePath == "" {
 		filePath = "gas.yml"
 	}
@@ -35,4 +35,5 @@ func (conf *ServicesConfig) Fill(filePath string) {
 	if err != nil {
         panic(err)
 	}
+    return &conf
 }


### PR DESCRIPTION
This PR aims to close issue #1, it adds the functionality to install packages that are defined in the YAML.

The package manager in the YAML needs to be the command name, the command args need to be anything else that needs to be ran for an automated install, and the packages will all install and everything will get logged to `installLog.txt`